### PR TITLE
Guess後の結果表示アニメーションを実装

### DIFF
--- a/ShiroGuessr/Views/Components/DashedLinePath.swift
+++ b/ShiroGuessr/Views/Components/DashedLinePath.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// A Shape that draws a straight line between two points in normalized coordinates (0-1).
+/// Compatible with `.trim(from:to:)` for animated drawing.
+struct DashedLinePath: Shape {
+    /// Start point in normalized coordinates (0-1)
+    let from: CGPoint
+    /// End point in normalized coordinates (0-1)
+    let to: CGPoint
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let start = CGPoint(
+            x: from.x * rect.width,
+            y: from.y * rect.height
+        )
+        let end = CGPoint(
+            x: to.x * rect.width,
+            y: to.y * rect.height
+        )
+        path.move(to: start)
+        path.addLine(to: end)
+        return path
+    }
+}

--- a/ShiroGuessr/Views/Screens/MapGameScreen.swift
+++ b/ShiroGuessr/Views/Screens/MapGameScreen.swift
@@ -106,7 +106,9 @@ struct MapGameScreen: View {
                     gradientMap: gradientMap,
                     userPin: currentRound.pin,
                     targetPin: viewModel.isRoundSubmitted ? currentRound.targetPin : nil,
-                    isInteractionEnabled: !viewModel.isRoundSubmitted,
+                    showTargetPinAnimated: viewModel.showTargetPin,
+                    lineDrawProgress: viewModel.lineDrawProgress,
+                    isInteractionEnabled: !viewModel.isRoundSubmitted && !viewModel.isAnimatingResult,
                     onPinPlacement: { coordinate in
                         viewModel.placePin(at: coordinate)
                     }
@@ -117,8 +119,8 @@ struct MapGameScreen: View {
 
                 // Game controls
                 GameControls(
-                    canSubmit: viewModel.hasPinPlaced,
-                    canProceed: viewModel.isRoundSubmitted,
+                    canSubmit: viewModel.hasPinPlaced && !viewModel.isAnimatingResult,
+                    canProceed: viewModel.isRoundSubmitted && !viewModel.isAnimatingResult,
                     onSubmit: {
                         viewModel.submitGuess()
                     },


### PR DESCRIPTION
## Summary

- Guess後に結果シートを即座に表示する代わりに、3フェーズのアニメーションシーケンスを挿入
  - **0〜400ms**: 正解ピンがスプリングアニメーション（dampingFraction: 0.55）でポップイン
  - **180〜600ms**: 回答ピンから正解ピンへの破線が描画アニメーション
  - **700ms〜**: 結果シートが表示
- アニメーション中はピン配置・Submit・Nextボタンを無効化
- タイムアウト時も同じアニメーションフローを使用

## 変更ファイル

- `MapGameViewModel.swift` — アニメーション状態管理（`startResultAnimation()`）
- `DashedLinePath.swift` — 新規Shape（正規化座標の2点間に直線を描画、`.trim()`対応）
- `GradientMapView.swift` — `AnimatedTargetPin`サブビューと破線オーバーレイ追加
- `MapGameScreen.swift` — アニメーション状態の受け渡し

## Test plan

- [ ] マップモードでピンを配置してGuess → 正解ピンがスプリングアニメーションでポップインすることを確認
- [ ] 破線が回答→正解間に描画されることを確認
- [ ] 約700ms後に結果シートが表示されることを確認
- [ ] タイムアウト時も同じアニメーションが再生されることを確認
- [ ] 次のラウンドに進んだ時にアニメーション状態がリセットされることを確認
- [ ] アニメーション中にSubmitボタン・Nextボタンが無効であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)