### PR TITLE
ゲーム中のRGB値表示を削除

### DIFF
--- a/ShiroGuessr/Views/Screens/MapGameScreen.swift
+++ b/ShiroGuessr/Views/Screens/MapGameScreen.swift
@@ -151,10 +151,6 @@ struct MapGameScreen: View {
                         .strokeBorder(Color.mdOutline, lineWidth: 1.5)
                 )
 
-            Text(color.toCSSString())
-                .font(.mdBodySmall)
-                .foregroundStyle(Color.mdOnSurfaceVariant)
-                .fontDesign(.monospaced)
         }
         .padding(12)
         .background(Color.mdSurfaceVariant.opacity(0.3))


### PR DESCRIPTION
## Summary
- ゲームプレイ中のターゲットカラー表示からRGB値（CSSカラーコード）を非表示にした
- ラウンド結果ダイアログのRGB値表示はそのまま維持

## Test plan
- [ ] ゲーム中のターゲットカラー表示にRGB値が表示されないこと
- [ ] ラウンド結果ダイアログではRGB値が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)