### PR TITLE
Deploy to TestFlightワークフローのプラットフォームエラーを修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
+  ruby
 
 DEPENDENCIES
   fastlane


### PR DESCRIPTION
## Summary
- CIランナー(macos-26 / arm64-darwin-23)で`bundle install`が失敗していた問題を修正
- `Gemfile.lock`に`arm64-darwin-23`と`ruby`プラットフォームを追加

## Test plan
- [ ] Deploy to TestFlightワークフローを手動実行し、Setup Rubyステップが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)