### PR TITLE
fastlane API Key JSONのkeyフィールドを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,11 +37,12 @@ jobs:
         chmod 600 ~/private_keys/AuthKey_$ASC_KEY_ID.p8
 
         # fastlane用のAPI Key JSONファイルを作成
+        KEY_CONTENT=$(awk '{printf "%s\\n", $0}' ~/private_keys/AuthKey_$ASC_KEY_ID.p8)
         cat > ~/private_keys/api_key.json <<EOF
         {
           "key_id": "$ASC_KEY_ID",
           "issuer_id": "$ASC_ISSUER_ID",
-          "key_filepath": "$HOME/private_keys/AuthKey_$ASC_KEY_ID.p8",
+          "key": "$KEY_CONTENT",
           "in_house": false
         }
         EOF


### PR DESCRIPTION
## Summary
- fastlane pilot uploadで `App Store Connect API key JSON is missing field(s): key` エラーが発生していた問題を修正
- API Key JSONの `key_filepath`（ファイルパス参照）を `key`（.p8キーの中身を直接埋め込み）に変更
- .p8ファイルの改行を `\n` にエスケープしてJSON文字列として正しく埋め込むようにした

## Test plan
- [ ] Deploy to TestFlight ワークフローを `workflow_dispatch` で手動実行し、Upload to TestFlight ステップが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)