### PR TITLE
ダークモード時の表示崩れを修正: アプリ全体をライトモードに固定

### DIFF
--- a/ShiroGuessr/ShiroGuessrApp.swift
+++ b/ShiroGuessr/ShiroGuessrApp.swift
@@ -96,6 +96,7 @@ struct ShiroGuessrApp: App {
     var body: some Scene {
         WindowGroup {
             RootView()
+                .preferredColorScheme(.light)
                 .onOpenURL { url in
                     handleUniversalLink(url)
                 }


### PR DESCRIPTION
## Summary
- デバイスがダークモードのとき、チュートリアルやリザルトシートの背景が暗くなる問題を修正
- `ShiroGuessrApp` のルートビューに `.preferredColorScheme(.light)` を適用し、アプリ全体をライトモードに固定
- カラーシステム（`ColorSystem.swift`）がライトモード専用のハードコード値のため、アプリ全体の固定が適切

## Test plan
- [ ] デバイスをダークモードに設定した状態でアプリを起動
- [ ] チュートリアルシートの背景が白で表示されることを確認
- [ ] ラウンドリザルトシートの背景が白で表示されることを確認
- [ ] 最終リザルト画面の背景が白で表示されることを確認
- [ ] ライトモードで従来通り表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)