### PR TITLE
共有URLのパスを /ios から /app に変更

### DIFF
--- a/ShiroGuessr/Services/ShareService.swift
+++ b/ShiroGuessr/Services/ShareService.swift
@@ -21,7 +21,7 @@ class ShareService {
             text += "\(L10n.Share.round(round.roundNumber)) \(stars) (\(L10n.Share.distance) \(distance))\n"
         }
 
-        text += "\nhttps://shiro-guessr.pages.dev/ios\n\n"
+        text += "\nhttps://shiro-guessr.pages.dev/app\n\n"
         text += "#白Guessr"
 
         return text

--- a/ShiroGuessr/ShiroGuessrApp.swift
+++ b/ShiroGuessr/ShiroGuessrApp.swift
@@ -103,15 +103,15 @@ struct ShiroGuessrApp: App {
         }
     }
 
-    /// Handle Universal Links from shiro-guessr.pages.dev/ios
+    /// Handle Universal Links from shiro-guessr.pages.dev/app
     /// - Parameter url: The incoming URL
     private func handleUniversalLink(_ url: URL) {
         // For now, just log the URL
         // In production, this could navigate to a specific screen or show a welcome message
         print("Received Universal Link: \(url)")
 
-        // Example: Check if it's the /ios path
-        if url.path == "/ios" || url.path.contains("/ios") {
+        // Example: Check if it's the /app path
+        if url.path == "/app" || url.path.contains("/app") {
             // App was opened from the share link
             // Could show a welcome message or tutorial
             print("App opened from share link")

--- a/ShiroGuessrTests/ShareServiceTests.swift
+++ b/ShiroGuessrTests/ShareServiceTests.swift
@@ -90,7 +90,7 @@ struct ShareServiceTests {
         // Should contain round numbers (language-agnostic check)
         #expect(shareText.contains("1:"))
         #expect(shareText.contains("5:"))
-        #expect(shareText.contains("https://shiro-guessr.pages.dev/ios"))
+        #expect(shareText.contains("https://shiro-guessr.pages.dev/app"))
         #expect(shareText.contains("#白Guessr"))
     }
 


### PR DESCRIPTION
## Summary
- 共有テキストに含まれるURLのパスを `/ios` から `/app` に変更
- Universal Link のパス判定も `/app` に統一
- テストの期待値を更新

## Test plan
- [ ] 共有テキストに `https://shiro-guessr.pages.dev/app` が含まれることを確認
- [ ] Universal Link で `/app` パスが正しくハンドルされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)