### PR TITLE
iPadで横向きをサポートし、必要時のみスクロールを有効化

### DIFF
--- a/ShiroGuessr.xcodeproj/project.pbxproj
+++ b/ShiroGuessr.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -509,6 +510,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ShiroGuessr/Views/Components/ScrollableIfNeeded.swift
+++ b/ShiroGuessr/Views/Components/ScrollableIfNeeded.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// A container that enables vertical scrolling only when the content
+/// exceeds the available height on iPad in landscape orientation.
+/// On iPhone or iPad in portrait, scrolling is disabled to prevent overscroll.
+struct ScrollableIfNeeded<Content: View>: View {
+    @ViewBuilder var content: Content
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
+
+    @State private var contentHeight: CGFloat = 0
+    @State private var containerHeight: CGFloat = 0
+
+    private var isIPadLandscape: Bool {
+        horizontalSizeClass == .regular && verticalSizeClass == .regular
+    }
+
+    private var needsScroll: Bool {
+        isIPadLandscape && contentHeight > containerHeight
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            if needsScroll {
+                ScrollView(.vertical, showsIndicators: true) {
+                    content
+                        .measureHeight { contentHeight = $0 }
+                }
+            } else {
+                content
+                    .measureHeight { contentHeight = $0 }
+            }
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { newValue in
+            containerHeight = newValue
+        }
+    }
+}
+
+// MARK: - Height measurement
+
+private struct HeightPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+private extension View {
+    func measureHeight(_ onChange: @escaping (CGFloat) -> Void) -> some View {
+        self
+            .background(
+                GeometryReader { geometry in
+                    Color.clear
+                        .preference(key: HeightPreferenceKey.self, value: geometry.size.height)
+                }
+            )
+            .onPreferenceChange(HeightPreferenceKey.self, perform: onChange)
+    }
+}

--- a/ShiroGuessr/Views/Screens/ClassicGameScreen.swift
+++ b/ShiroGuessr/Views/Screens/ClassicGameScreen.swift
@@ -16,60 +16,64 @@ struct ClassicGameScreen: View {
                 if let currentRound = viewModel.currentRound,
                    viewModel.isGameActive {
                     // Active game view
-                    VStack(spacing: 20) {
+                    VStack(spacing: 0) {
                         // Header
                         GameHeader(onModeButtonTap: {
                             onModeToggle?()
                         })
-                        
-                        // Score board
-                        ScoreBoard(
-                            currentRound: currentRound.roundNumber,
-                            totalRounds: 5,
-                            currentScore: viewModel.gameState?.totalScore ?? 0
-                        )
-                        
-                        // Target color display
-                        VStack(spacing: 12) {
-                            Text(L10n.Game.findThisColorColon)
-                                .font(.mdTitleMedium)
-                                .foregroundStyle(Color.mdOnSurface)
-                            
-                            RoundedRectangle(cornerRadius: 16)
-                                .fill(currentRound.targetColor.toColor())
-                                .frame(height: 80)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 16)
-                                        .strokeBorder(Color.mdOutline, lineWidth: 2)
+
+                        ScrollableIfNeeded {
+                            VStack(spacing: 20) {
+                                // Score board
+                                ScoreBoard(
+                                    currentRound: currentRound.roundNumber,
+                                    totalRounds: 5,
+                                    currentScore: viewModel.gameState?.totalScore ?? 0
                                 )
-                                .shadow(color: Color.mdShadow, radius: 4, x: 0, y: 2)
+
+                                // Target color display
+                                VStack(spacing: 12) {
+                                    Text(L10n.Game.findThisColorColon)
+                                        .font(.mdTitleMedium)
+                                        .foregroundStyle(Color.mdOnSurface)
+
+                                    RoundedRectangle(cornerRadius: 16)
+                                        .fill(currentRound.targetColor.toColor())
+                                        .frame(height: 80)
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 16)
+                                                .strokeBorder(Color.mdOutline, lineWidth: 2)
+                                        )
+                                        .shadow(color: Color.mdShadow, radius: 4, x: 0, y: 2)
+                                        .padding(.horizontal, 16)
+                                }
+
+                                // Color palette
+                                ColorPalette(
+                                    colors: currentRound.paletteColors,
+                                    selectedColor: viewModel.selectedColor,
+                                    onColorSelected: { color in
+                                        viewModel.selectColor(color)
+                                    },
+                                    isEnabled: !viewModel.isRoundSubmitted
+                                )
                                 .padding(.horizontal, 16)
-                        }
-                        
-                        // Color palette
-                        ColorPalette(
-                            colors: currentRound.paletteColors,
-                            selectedColor: viewModel.selectedColor,
-                            onColorSelected: { color in
-                                viewModel.selectColor(color)
-                            },
-                            isEnabled: !viewModel.isRoundSubmitted
-                        )
-                        .padding(.horizontal, 16)
-                        
-                        // Controls
-                        GameControls(
-                            canSubmit: viewModel.hasSelectedColor && !viewModel.isRoundSubmitted,
-                            canProceed: viewModel.isRoundSubmitted,
-                            onSubmit: {
-                                viewModel.submitAnswer()
-                            },
-                            onNext: {
-                                viewModel.nextRound()
+
+                                // Controls
+                                GameControls(
+                                    canSubmit: viewModel.hasSelectedColor && !viewModel.isRoundSubmitted,
+                                    canProceed: viewModel.isRoundSubmitted,
+                                    onSubmit: {
+                                        viewModel.submitAnswer()
+                                    },
+                                    onNext: {
+                                        viewModel.nextRound()
+                                    }
+                                )
+
+                                Spacer(minLength: 20)
                             }
-                        )
-                        
-                        Spacer(minLength: 20)
+                        }
                     }
                 } else if let gameState = viewModel.gameState,
                           gameState.isCompleted {

--- a/ShiroGuessr/Views/Screens/MapGameScreen.swift
+++ b/ShiroGuessr/Views/Screens/MapGameScreen.swift
@@ -89,28 +89,25 @@ struct MapGameScreen: View {
                 onModeToggle?()
             })
 
-            VStack(spacing: 8) {
-                // Score board
-                ScoreBoard(
-                    currentRound: currentRound.roundNumber,
-                    totalRounds: gameState.rounds.count,
-                    currentScore: gameState.totalScore
-                )
+            ScrollableIfNeeded {
+                VStack(spacing: 8) {
+                    // Score board
+                    ScoreBoard(
+                        currentRound: currentRound.roundNumber,
+                        totalRounds: gameState.rounds.count,
+                        currentScore: gameState.totalScore
+                    )
 
-                // Timer display
-                TimerDisplay(timeRemaining: viewModel.timeRemaining)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.horizontal, 16)
+                    // Timer display
+                    TimerDisplay(timeRemaining: viewModel.timeRemaining)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.horizontal, 16)
 
-                // Target color display
-                targetColorView(color: currentRound.targetColor)
+                    // Target color display
+                    targetColorView(color: currentRound.targetColor)
 
-                // Gradient map view with adaptive sizing for iPad
-                GeometryReader { geometry in
-                    let availableWidth = geometry.size.width - 32 // account for horizontal padding
-                    let mapSize: CGFloat = horizontalSizeClass == .regular
-                        ? min(availableWidth, 500)
-                        : min(availableWidth, 300)
+                    // Gradient map view with adaptive sizing for iPad
+                    let mapSize: CGFloat = horizontalSizeClass == .regular ? 500 : 300
 
                     GradientMapView(
                         gradientMap: gradientMap,
@@ -124,25 +121,25 @@ struct MapGameScreen: View {
                             viewModel.placePin(at: coordinate)
                         }
                     )
+                    .frame(width: mapSize, height: mapSize)
                     .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 16)
+
+                    Spacer(minLength: 8)
+
+                    // Game controls
+                    GameControls(
+                        canSubmit: viewModel.hasPinPlaced && !viewModel.isAnimatingResult,
+                        canProceed: viewModel.isRoundSubmitted && !viewModel.isAnimatingResult,
+                        onSubmit: {
+                            viewModel.submitGuess()
+                        },
+                        onNext: {
+                            viewModel.nextRound()
+                        }
+                    )
+                    .padding(.bottom, 16)
                 }
-                .frame(height: horizontalSizeClass == .regular ? 500 : 300)
-                .padding(.horizontal, 16)
-
-                Spacer(minLength: 8)
-
-                // Game controls
-                GameControls(
-                    canSubmit: viewModel.hasPinPlaced && !viewModel.isAnimatingResult,
-                    canProceed: viewModel.isRoundSubmitted && !viewModel.isAnimatingResult,
-                    onSubmit: {
-                        viewModel.submitGuess()
-                    },
-                    onNext: {
-                        viewModel.nextRound()
-                    }
-                )
-                .padding(.bottom, 16)
             }
         }
     }


### PR DESCRIPTION
## Summary
- iPadのみ横向き（Landscape）をサポートするよう `UISupportedInterfaceOrientations_iPad` を追加（iPhoneは縦のまま）
- `ScrollableIfNeeded` コンポーネントを導入：iPadかつ横向き時にコンテンツが画面を超えた場合のみスクロールを有効化し、収まる場合はoverscrollを防止
- `MapGameScreen` と `ClassicGameScreen` のゲーム画面にヘッダー固定＋条件付きスクロールを適用

## Test plan
- [ ] iPadシミュレータで横向きに回転できることを確認
- [ ] iPad横向きでコンテンツが収まる場合、スクロールが無効（overscrollしない）であることを確認
- [ ] iPad横向きでコンテンツが画面を超える場合、スクロールが効くことを確認
- [ ] iPad縦向きで従来通りスクロールなしで表示されることを確認
- [ ] iPhoneで横向きに回転しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)